### PR TITLE
Replace Contact card with text link, move quote below photo

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,11 @@
       "Bash(curl:*)",
       "Bash(ls:*)",
       "WebFetch(domain:commons.wikimedia.org)",
-      "Bash(git push -u origin claude/website-review-g6xfo)"
+      "Bash(git push -u origin claude/website-review-g6xfo)",
+      "Bash(npx astro:*)",
+      "Bash(gh pr:*)",
+      "WebSearch",
+      "mcp__Claude_Preview__preview_start"
     ]
   }
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,11 +22,6 @@ const navCards = [
     label: 'Now',
     description: "What I'm currently playing, watching, obsessing over.",
   },
-  {
-    href: '/contact',
-    label: 'Contact',
-    description: "I promise I'm friendly!",
-  },
 ];
 ---
 
@@ -101,9 +96,9 @@ const navCards = [
     ))}
   </section>
 
-  <!-- Quote -->
-  <p id="mindfulness-quote" class="mb-10" style="color: var(--color-muted); transition: opacity 0.6s ease; min-height: 1.5em;">
-    &nbsp;
+  <!-- Contact text link -->
+  <p class="contact-cta mb-10">
+    Want to chat? <a href="/contact" class="contact-link">Say hello</a> — I promise I'm friendly.
   </p>
 
   <!-- Gradient divider -->
@@ -114,6 +109,11 @@ const navCards = [
     <img src="/images/home/gc1.jpg" alt="Horseshoe Bend, Arizona" class="photo-banner" />
     <p class="photo-caption">Horseshoe Bend, Arizona, 2026</p>
   </section>
+
+  <!-- Quote -->
+  <p id="mindfulness-quote" class="mt-10" style="color: var(--color-muted); transition: opacity 0.6s ease; min-height: 1.5em;">
+    &nbsp;
+  </p>
 </BaseLayout>
 
 <style>
@@ -236,6 +236,23 @@ const navCards = [
     line-height: 1.5;
     color: var(--color-muted);
     position: relative;
+  }
+
+  /* Contact CTA text link */
+  .contact-cta {
+    color: var(--color-muted);
+    font-size: 0.9rem;
+  }
+
+  .contact-link {
+    color: var(--color-accent-light);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    transition: color 0.2s;
+  }
+
+  .contact-link:hover {
+    color: var(--color-heading);
   }
 
   /* Photo banner */


### PR DESCRIPTION
Removes Contact from the nav grid to restore 2x2 symmetry, adds a subtle 'Want to chat? Say hello' text link beneath the grid, and moves the mindfulness quote to below the photo banner above the footer.